### PR TITLE
Create deep folders for fixtures if needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /Gemfile.lock
 /.yardoc
 *.gem
+/spec/tmp

--- a/lib/rspec_fixtures.rb
+++ b/lib/rspec_fixtures.rb
@@ -1,5 +1,7 @@
 require 'rspec_fixtures/version'
 
+require 'rspec_fixtures/extensions/file'
+
 require 'rspec_fixtures/stream_capturer'
 require 'rspec_fixtures/approval_handler'
 require 'rspec_fixtures/matchers/base'

--- a/lib/rspec_fixtures/approval_handler.rb
+++ b/lib/rspec_fixtures/approval_handler.rb
@@ -22,7 +22,7 @@ module RSpecFixtures
       
       if user_approves?
         say "!txtgrn!Approved"
-        File.write fixture_file, actual
+        File.deep_write fixture_file, actual
         true
       else
         say "!txtred!Not Approved"

--- a/lib/rspec_fixtures/extensions/file.rb
+++ b/lib/rspec_fixtures/extensions/file.rb
@@ -1,0 +1,9 @@
+require 'fileutils'
+
+class File
+  def self.deep_write(file, content)
+    dir = File.dirname file
+    FileUtils.mkdir_p dir unless Dir.exist? dir
+    File.write file, content
+  end
+end

--- a/lib/rspec_fixtures/matchers/base.rb
+++ b/lib/rspec_fixtures/matchers/base.rb
@@ -45,9 +45,7 @@ module RSpecFixtures
       end
 
       def expected!
-        Dir.mkdir fixtures_dir unless Dir.exist? fixtures_dir
-        File.write fixture_file, nil unless File.exist? fixture_file
-        File.read fixture_file
+        File.exist?(fixture_file) ? File.read(fixture_file) : ''
       end
     end
 

--- a/spec/rspec_fixtures/approval_handler_spec.rb
+++ b/spec/rspec_fixtures/approval_handler_spec.rb
@@ -18,7 +18,16 @@ describe ApprovalHandler do
           expect(subject.run 'expected', 'actual', fixture).to be true
         end
         expect(File.read fixture).to eq 'actual'
-      end      
+      end
+
+      context "when the fixture folders do not exist" do
+        it "creates them using deep_write" do
+          expect(File).to receive(:deep_write).with('some/deep/path', 'actual')
+          supress_output do
+            subject.run 'expected', 'actual', 'some/deep/path'
+          end
+        end
+      end
     end
 
     context "when the user answers n(o)" do

--- a/spec/rspec_fixtures/extensions/file_spec.rb
+++ b/spec/rspec_fixtures/extensions/file_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe File do
+  describe '::deep_write' do
+    let(:file) { 'spec/tmp/subfolder/filename' }
+    let(:dir) { File.dirname file }
+
+    before do
+      File.delete file if File.exist? file
+      Dir.delete dir if Dir.exist? dir  
+      expect(File).not_to exist file
+      expect(Dir).not_to exist dir
+    end
+
+    it "writes to a file and creates parent folders" do
+      File.deep_write file, 'content'
+      expect(File).to exist file
+      expect(File.read file).to eq 'content'
+    end
+  end
+
+end

--- a/spec/rspec_fixtures/matchers/base_spec.rb
+++ b/spec/rspec_fixtures/matchers/base_spec.rb
@@ -24,20 +24,6 @@ describe Matchers::Base do
     it "loads fixture content from a file" do
       expect(subject.expected).to eq File.read('spec/fixtures/something')
     end
-
-    context "when the fixture file is not present" do
-      subject { Matchers::Base.new 'create_me_please' }
-      let(:file) { 'spec/fixtures/create_me_please' }
-      before do 
-        File.delete file if File.exist? file
-        expect(File).not_to exist file
-      end
-
-      it "creates it" do
-        subject.expected
-        expect(File).to exist file
-      end
-    end
   end
 
   describe '#failure_message' do


### PR DESCRIPTION
This PR moves the directory creation from `Matchers::Base#expected!` to `Approva
lHandler`.

We will now use `File.deep_write` (extension) to create the fixture, and its par
ent directories if needed.