### PR TITLE
Switch back to using getch instead of gets

### DIFF
--- a/lib/rspec_fixtures/approval_handler.rb
+++ b/lib/rspec_fixtures/approval_handler.rb
@@ -1,4 +1,5 @@
 require 'colsole'
+require 'io/console'
 
 module RSpecFixtures
   class ApprovalHandler
@@ -33,9 +34,7 @@ module RSpecFixtures
     private
 
     def user_approves?
-      # NOTE: getc does not work, therefore using gets
-      #       See: https://stackoverflow.com/questions/48459605/ruby-2-5-0-stdin-getc-does-not-work-on-consecutive-calls
-      $stdin.gets =~ /^[Yy]/
+      $stdin.getch =~ /[Yy]/
     end
   end
 end

--- a/spec/rspec_fixtures/matchers/match_fixture_spec.rb
+++ b/spec/rspec_fixtures/matchers/match_fixture_spec.rb
@@ -43,7 +43,7 @@ describe Matchers::MatchFixture do
         end
 
         it "asks for approval and creates the fixture" do
-          expect($stdin).to receive(:gets).and_return "y\n"
+          expect($stdin).to receive(:getch).and_return "y"
           expect{ subject.matches? 'no_such_fixture' }.to output(/Approve new fixture/).to_stdout
           expect(File).to exist(file)
         end

--- a/spec/rspec_fixtures/stdin_spec.rb
+++ b/spec/rspec_fixtures/stdin_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
+require 'io/console'
 
 # Why is this spec even here? ... This is a weird one...
 #
 # 1. We used to use `$stdin.getch` to get user input
-# 2. It seems `$stdin.getch` is only available in ruby 2.4.2, and in other 
-#    versions it is `$stdin.getc`
+# 2. It seems `$stdin.getch` worked in ruby 2.4.2 without requiring
+#    `io/console`.
 # 3. Tests in all ruby versions passed on Travis, since `$stdin` is 
 #    stubbed (here is a good reason why stubbing is problematic)
-# 4. We switched to using `$stdin.getc` but (sigh...) it is broken
-#    in ruby 2.5, see this StackOverflow: https://goo.gl/uaSQMS
-# 5. Finally, we switched to using gets instead.
 #
 # So - since `$stdin` is still stubbed, we just want to make sure
-# ruby doesn't break its `gets` method...
+# it responds to getch when tested on travis in other ruby versions
 
 describe :stdin do
-  it "responds to gets" do
-    expect($stdin).to respond_to :gets
+  it "responds to getch" do
+    expect($stdin).to respond_to :getch
   end
 end


### PR DESCRIPTION
This PR switches back from `$stdin.gets` to `$stdin.getch`, and requires `io/console`.

See [this StackOverflow question](https://goo.gl/uaSQMS) for the backstory.