### PR TITLE
Change order of approval display

### DIFF
--- a/lib/rspec_fixtures/approval_handler.rb
+++ b/lib/rspec_fixtures/approval_handler.rb
@@ -12,11 +12,11 @@ module RSpecFixtures
       if expected.empty?
         say actual
       else
-        say "> New (Actual):"
-        say actual
-        say "!txtpur!#{line}"
         say "> Old (Fixture):"
         say expected
+        say "!txtpur!#{line}"
+        say "> New (Actual):"
+        say actual
       end
       say "!txtgrn!#{line}"
       say "> Approve new fixture? (y/N): "


### PR DESCRIPTION
Show old fixture before new fixtures when doing interactive approvals, for conve
nience (so that no matter if it is a new or updated fixture, it is shown right b
efore the prompt).