### PR TITLE
Fix missing string-similarity dependency

### DIFF
--- a/lib/rspec_fixtures/version.rb
+++ b/lib/rspec_fixtures/version.rb
@@ -1,3 +1,3 @@
 module RSpecFixtures
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/rspec_fixtures.gemspec
+++ b/rspec_fixtures.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.0.0"
 
   s.add_runtime_dependency 'colsole', '~> 0.5'
+  s.add_runtime_dependency 'string-similarity', '~> 2.0'
 
   s.add_development_dependency 'rspec', '~> 3.7'
   s.add_development_dependency 'runfile', '~> 0.9'
@@ -24,5 +25,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'byebug', '~> 9.0'
   s.add_development_dependency 'simplecov', '~> 0.14'
   s.add_development_dependency 'yard', '~> 0.9'
-  s.add_development_dependency 'string-similarity', '~> 2.0'
 end


### PR DESCRIPTION
This PR moves the `string-similarity` dependency from development to runtime.