### PR TITLE
Add support for auto-approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ end
 
 ### `auto_approve`
 
-If you wish to automatically approvoe all new or changed fixtures, you can
+If you wish to automatically approve all new or changed fixtures, you can
 set the `auto_approve` configuration option to `true`. By default, 
 auto approval is enabled if the environment variable `AUTO_APPROVE` is set.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ expect{ puts 'some string' }.to output_fixture('fixture_filename').diff(5)
 ### `except` - Exclude by regular expression
 
 Adding `except(regex)` to either `match_fixture` or `output_fixture` will
-modify the string under test before runnign. The supplied regular expression
+modify the string under test before running. The supplied regular expression
 must include exactly one capture group, which will be then replaced by '...'.
 
 In the below example, we ignore the full path of the file.

--- a/README.md
+++ b/README.md
@@ -158,4 +158,25 @@ end
 ```
 
 
+### `auto_approve`
+
+If you wish to automatically approvoe all new or changed fixtures, you can
+set the `auto_approve` configuration option to `true`. By default, 
+auto approval is enabled if the environment variable `AUTO_APPROVE` is set.
+
+```ruby
+RSpec.configure do |config|
+  config.auto_approve = true # or any logic
+end
+```
+
+This feature is intended to help clean up the fixtures folder from old, no
+longer used files. Simply run the specs once, to ensure they all oass, 
+delete the fixtures folder, and run the specs again with:
+
+```
+$ AUTO_APPROVE=1 rspec
+```
+
+
 [1]: https://en.wikipedia.org/wiki/Levenshtein_distance

--- a/lib/rspec_fixtures/approval_handler.rb
+++ b/lib/rspec_fixtures/approval_handler.rb
@@ -23,7 +23,7 @@ module RSpecFixtures
     private
 
     def prompt_user
-      response = get_response
+      response = auto_approve? ? :approve : get_response
 
       case response
 
@@ -38,6 +38,10 @@ module RSpecFixtures
         false
 
       end
+    end
+
+    def auto_approve?
+      RSpec.configuration.auto_approve
     end
 
     def get_response

--- a/lib/rspec_fixtures/rspec_config.rb
+++ b/lib/rspec_fixtures/rspec_config.rb
@@ -4,5 +4,6 @@ if defined? RSpec
     config.include RSpecFixtures::Matchers
     config.add_setting :fixtures_path, default: File.expand_path('spec/fixtures')
     config.add_setting :interactive_fixtures, default: !ENV['CI']
+    config.add_setting :auto_approve, default: ENV['AUTO_APPROVE']
   end
 end

--- a/spec/rspec_fixtures/approval_handler_spec.rb
+++ b/spec/rspec_fixtures/approval_handler_spec.rb
@@ -12,7 +12,7 @@ describe ApprovalHandler do
       before { File.delete fixture if File.exist? fixture }
 
       it "only asks the user to Approve or Reject" do
-        # Check that evern after going down twice, we still remain at Approve
+        # Check that even after going down twice, we still remain at Approve
         stdin_send down_arrow, down_arrow, "\n" do
           expect{ subject.run 'expected', 'actual', fixture }.to output(/Approved/).to_stdout
         end
@@ -60,6 +60,19 @@ describe ApprovalHandler do
           end
           expect(File).not_to exist fixture
         end      
+      end
+
+      context "when auto_approve is configured to true", :focus do
+        before { RSpec.configuration.auto_approve = true }
+        after  { RSpec.configuration.auto_approve = false }
+
+        it "does not prompt the user for approval" do
+          expect(subject).not_to receive(:get_response)
+          supress_output do
+            expect(subject.run 'expected', 'actual', fixture).to be true
+          end
+          expect(File.read fixture).to eq 'actual'
+        end
       end
 
     end

--- a/spec/rspec_fixtures/approval_handler_spec.rb
+++ b/spec/rspec_fixtures/approval_handler_spec.rb
@@ -62,7 +62,7 @@ describe ApprovalHandler do
         end      
       end
 
-      context "when auto_approve is configured to true", :focus do
+      context "when auto_approve is configured to true" do
         before { RSpec.configuration.auto_approve = true }
         after  { RSpec.configuration.auto_approve = false }
 


### PR DESCRIPTION
After using `rspec_fixtures` for a long time, the fixtures folder may become polluted with older, no longer used approval files.

With this PR it is easy to clean them up:

1. Run `rspec` normally, to ensure all tests pass.
2. Delete the fixtures folder
3. Run `AUTO_APPROVE=1 rspec`

This method will answer "Approve" automatically instead of prompting the user, and therefore, will create all needed fixtures again.

There is also a new rspec configuration option to match.
