### PR TITLE
Add option to remove ansi escape chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,5 +188,16 @@ delete the fixtures folder, and run the specs again with:
 $ AUTO_APPROVE=1 rspec
 ```
 
+### `strip_ansi_escape`
+
+In case your output strings contain ANSI escape codes that you wish to avoid
+storing in your fixtures, you can set the `strip_ansi_escape` to `true`.
+
+```ruby
+RSpec.configure do |config|
+  config.strip_ansi_escape = true
+end
+```
+
 
 [1]: https://en.wikipedia.org/wiki/Levenshtein_distance

--- a/lib/rspec_fixtures/matchers/base.rb
+++ b/lib/rspec_fixtures/matchers/base.rb
@@ -12,6 +12,11 @@ module RSpecFixtures
       # Called by RSpec. This will be overridden by child matchers.
       def matches?(actual)
         @actual ||= actual
+
+        if RSpec.configuration.strip_ansi_escape
+          @actual = Strings::ANSI.sanitize @actual
+        end
+
         return false if @actual.empty?
 
         success = strings_match?

--- a/lib/rspec_fixtures/matchers/base.rb
+++ b/lib/rspec_fixtures/matchers/base.rb
@@ -132,6 +132,8 @@ module RSpecFixtures
         end
       end
 
+      # Returns the input string stripped of ANSI escape codes if the 
+      # strip_ansi_escape configuration setting was set to true
       def sanitize(string)
         sanitize? ? Strings::ANSI.sanitize(string) : string
       end

--- a/lib/rspec_fixtures/matchers/base.rb
+++ b/lib/rspec_fixtures/matchers/base.rb
@@ -12,13 +12,9 @@ module RSpecFixtures
       # Called by RSpec. This will be overridden by child matchers.
       def matches?(actual)
         @actual ||= actual
-
-        if RSpec.configuration.strip_ansi_escape
-          @actual = Strings::ANSI.sanitize @actual
-        end
-
         return false if @actual.empty?
 
+        @actual = sanitize @actual
         success = strings_match?
 
         if success or !interactive?
@@ -78,6 +74,12 @@ module RSpecFixtures
         true
       end
 
+      # Returns true if RSpec is configured to sanitize (remove ANSI escape
+      # codes) from the actual strings before proceeeding to comparing them.
+      def sanitize?
+        RSpec.configuration.strip_ansi_escape
+      end
+
       # Returns true if RSpec is configured to allow interactivity.
       # By default, interactivity is enabled unless the environment 
       # variable `CI` is set.
@@ -96,7 +98,7 @@ module RSpecFixtures
         "#{fixtures_dir}/#{fixture_name}"
       end
       
-      protected
+    protected
 
       # Asks for user approval. Used by child classes.
       def approve_fixture
@@ -130,6 +132,9 @@ module RSpecFixtures
         end
       end
 
+      def sanitize(string)
+        sanitize? ? Strings::ANSI.sanitize(string) : string
+      end
     end
 
   end

--- a/lib/rspec_fixtures/rspec_config.rb
+++ b/lib/rspec_fixtures/rspec_config.rb
@@ -5,5 +5,6 @@ if defined? RSpec
     config.add_setting :fixtures_path, default: File.expand_path('spec/fixtures')
     config.add_setting :interactive_fixtures, default: !ENV['CI']
     config.add_setting :auto_approve, default: ENV['AUTO_APPROVE']
+    config.add_setting :strip_ansi_escape, default: false
   end
 end

--- a/lib/rspec_fixtures/stream_capturer.rb
+++ b/lib/rspec_fixtures/stream_capturer.rb
@@ -1,3 +1,5 @@
+require 'strings-ansi'
+
 module RSpecFixtures
   # Capture stdout and stderr
   #
@@ -13,6 +15,7 @@ module RSpecFixtures
       block.call
 
       captured_stream.string
+
     ensure
       $stdout = original_stream
     end
@@ -28,6 +31,7 @@ module RSpecFixtures
       block.call
 
       captured_stream.string
+      
     ensure
       $stderr = original_stream
     end

--- a/rspec_fixtures.gemspec
+++ b/rspec_fixtures.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'string-similarity', '~> 2.0'
   s.add_runtime_dependency 'diffy', '~> 3.3'
   s.add_runtime_dependency 'tty-prompt', '~> 0.19'
+  s.add_runtime_dependency 'strings-ansi', '~> 0.1'
 end

--- a/spec/rspec_fixtures/matchers/base_spec.rb
+++ b/spec/rspec_fixtures/matchers/base_spec.rb
@@ -37,7 +37,7 @@ describe Matchers::Base do
       end
     end
 
-    context "when strip_ansi_escape is on", :focus do
+    context "when strip_ansi_escape is on" do
       before :all do 
         RSpec.configuration.strip_ansi_escape = true
       end

--- a/spec/rspec_fixtures/matchers/base_spec.rb
+++ b/spec/rspec_fixtures/matchers/base_spec.rb
@@ -37,6 +37,22 @@ describe Matchers::Base do
       end
     end
 
+    context "when strip_ansi_escape is on", :focus do
+      before :all do 
+        RSpec.configuration.strip_ansi_escape = true
+      end
+
+      after :all do
+        RSpec.configuration.strip_ansi_escape = false
+      end
+
+      it "removes ansi codes from the actual string" do
+        subject.matches? "\e[33;44msomething\e[0m"
+        expect(subject.actual).to eq 'something'
+      end
+
+    end
+
     context "with .diff" do
       before do
         subject.diff 5


### PR DESCRIPTION
This PR adds the ability to strip all ANSI escape characters from any `actual` input before comparing it with `expected`.

```ruby
RSpec.configure do |config|
  config.strip_ansi_escape = true
end
```

This is usually not needed, and should remain at its default (`false`) setting unless you encounter issues.

As a general rule, if your output is generating ANSI escape codes that are NOT colors, it is probably going to generate more consistent results with this setting set to `true`.

