### PR TITLE
Add global before_approval filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ delete the fixtures folder, and run the specs again with:
 $ AUTO_APPROVE=1 rspec
 ```
 
+
 ### `strip_ansi_escape`
 
 In case your output strings contain ANSI escape codes that you wish to avoid
@@ -207,6 +208,24 @@ RSpec.configure do |config|
   config.strip_ansi_escape = true
 end
 ```
+
+
+### `before_approval`
+
+In case you need to alter the actual output globally, you can provide the
+`before_approval` option with a proc. The proc will receive the actual
+output - similarly to the `before` modifier - and is expectedd to return
+a modified actual string.
+
+```ruby
+RSpec.configure do |config|
+  config.before_approval = ->(actual) do
+    # return the actual string, without IP addresses
+    actual.gsub(/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/, '[IP REMOVED]')
+  end
+end
+```
+
 
 
 Advanced Usage Tips

--- a/lib/rspec_fixtures/matchers/base.rb
+++ b/lib/rspec_fixtures/matchers/base.rb
@@ -113,6 +113,8 @@ module RSpecFixtures
       # Do the actual test. 
       # - If .before() was used, we foreward the actual output to the
       #   proc for processing first.
+      # - If before_approval proc was configured, forward the acual output
+      #   to the proc for processing.
       # - If .diff() was used, then distance will be set and then 
       #   we "levenshtein it". 
       # - Otherwise, compare with ==
@@ -121,6 +123,10 @@ module RSpecFixtures
           @before.each do |proc|
             @actual = proc.call actual 
           end
+        end
+        
+        if RSpec.configuration.before_approval.is_a? Proc
+          @actual = RSpec.configuration.before_approval.call actual
         end
 
         if distance

--- a/lib/rspec_fixtures/rspec_config.rb
+++ b/lib/rspec_fixtures/rspec_config.rb
@@ -6,5 +6,6 @@ if defined? RSpec
     config.add_setting :interactive_fixtures, default: !ENV['CI']
     config.add_setting :auto_approve, default: ENV['AUTO_APPROVE']
     config.add_setting :strip_ansi_escape, default: false
+    config.add_setting :before_approval, default: nil
   end
 end

--- a/lib/rspec_fixtures/stream.rb
+++ b/lib/rspec_fixtures/stream.rb
@@ -8,39 +8,33 @@ module RSpecFixtures
   module Stream
     module Stdout
       def self.capture(block)
-        captured_stream = RSpecFixtures.stdout
+        RSpecFixtures.stdout.truncate 0
+        RSpecFixtures.stdout.rewind
 
         original_stream = $stdout
-        $stdout = captured_stream
-
+        $stdout = RSpecFixtures.stdout
         block.call
-
-        result = captured_stream.string.dup
-        captured_stream.truncate 0
-        captured_stream.rewind
-        result
+        RSpecFixtures.stdout.string.dup
 
       ensure
         $stdout = original_stream
+
       end
     end
 
     module Stderr
       def self.capture(block)
-        captured_stream = RSpecFixtures.stderr
+        RSpecFixtures.stderr.truncate 0
+        RSpecFixtures.stderr.rewind
 
         original_stream = $stderr
-        $stderr = captured_stream
-
+        $stderr = RSpecFixtures.stderr
         block.call
+        RSpecFixtures.stderr.string.dup
 
-        result = captured_stream.string.dup
-        captured_stream.truncate 0
-        captured_stream.rewind
-        result
-        
       ensure
         $stderr = original_stream
+
       end
     end
   end

--- a/spec/rspec_fixtures/matchers/base_spec.rb
+++ b/spec/rspec_fixtures/matchers/base_spec.rb
@@ -130,6 +130,23 @@ describe Matchers::Base do
       end
     end
 
+    context "when before_approval is set" do
+      before :all do 
+        RSpec.configuration.before_approval = ->(actual) do
+          "MODIFIED #{actual} MODIFIED"
+        end
+      end
+
+      after :all do
+        RSpec.configuration.before_approval = nil
+      end
+
+      it "sends the actual output to the proc before comparing" do
+        subject.matches? "something"
+        expect(subject.actual).to eq 'MODIFIED something MODIFIED'
+      end
+    end
+
   end
 
   describe '#expected' do


### PR DESCRIPTION
Add a global `before_approval` configuration, that receives a proc. The proc will receive the actual output, and can then manipulate it (e.g. replace IP addresses, log timestamps etc) so that the compared actual string is consistent across runs.

This is similar to the `before` modifier, but on a global level.

```ruby
# spec/spec_helper.rb
RSpec.configure do |config|
  config.before_approval = ->(actual) do
    actual.gsub(/(\d{1,3}\.){3}\d{1,3}/, '[IP REMOVED]')
  end
end
```
