### PR TITLE
Fix some cases of StringIO#ioctl errors

### DIFF
--- a/lib/rspec_approvals.rb
+++ b/lib/rspec_approvals.rb
@@ -1,4 +1,5 @@
 require 'rspec_approvals/extensions/file'
+require 'rspec_approvals/extensions/stringio'
 
 require 'rspec_approvals/module_functions'
 require 'rspec_approvals/prompt'

--- a/lib/rspec_approvals/extensions/stringio.rb
+++ b/lib/rspec_approvals/extensions/stringio.rb
@@ -1,0 +1,28 @@
+# This is a fix for a pesky issue with tty-screen, which is a sub-dependency
+# of tty-* gems.
+# Without this fix, gems that include rspec_approval and tty-* gems might
+# cause an error in some cases.
+#
+# ref: https://github.com/piotrmurach/tty-screen/issues/11
+require 'stringio'
+
+unless StringIO.method_defined? :ioctl
+  class StringIO
+    def ioctl(*)
+      # :nocov:
+      80
+      # :nocov:
+    end
+  end
+end
+
+unless StringIO.method_defined? :wait_readable
+  class StringIO
+    def wait_readable(*)
+      # :nocov:
+      true
+      # :nocov:
+    end
+  end
+end
+

--- a/lib/rspec_approvals/version.rb
+++ b/lib/rspec_approvals/version.rb
@@ -1,3 +1,3 @@
 module RSpecApprovals
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end


### PR DESCRIPTION
Even though we no longer have `tty-prompt`, [this issue](https://github.com/piotrmurach/tty-screen/issues/11) has come back to haunt us.

When using `rspec_approvals` in a gem that uses `tty-table` (for example, but probably some other `tty-*` cases), then the "no method StringIO#ioctl" error occurs again.

This was observed in the [datamix gem](https://github.com/DannyBen/datamix).

Hopefully this fix has no side effects.