### PR TITLE
Suppress stdout and stderr when using output matchers

### DIFF
--- a/lib/rspec_approvals/stream.rb
+++ b/lib/rspec_approvals/stream.rb
@@ -6,35 +6,36 @@ module RSpecApprovals
   # These methods are borrowed from rspec's built in matchers
   # https://github.com/rspec/rspec-expectations/blob/add9b271ecb1d65f7da5bc8a9dd8c64d81d92303/lib/rspec/matchers/built_in/output.rb
   module Stream
-    module Stdout
-      def self.capture(block)
+    module Capture
+      def self.capture(stream, block)
         RSpecApprovals.stdout.truncate 0
         RSpecApprovals.stdout.rewind
+        RSpecApprovals.stderr.truncate 0
+        RSpecApprovals.stderr.rewind
 
-        original_stream = $stdout
+        stdout_original_stream = $stdout
+        stderr_original_stream = $stderr
         $stdout = RSpecApprovals.stdout
+        $stderr = RSpecApprovals.stderr
         block.call
-        RSpecApprovals.stdout.string.dup
+        RSpecApprovals.send(stream).string.dup
 
       ensure
-        $stdout = original_stream
+        $stdout = stdout_original_stream
+        $stderr = stderr_original_stream
 
+      end
+    end
+
+    module Stdout
+      def self.capture(block)
+        Capture.capture :stdout, block
       end
     end
 
     module Stderr
       def self.capture(block)
-        RSpecApprovals.stderr.truncate 0
-        RSpecApprovals.stderr.rewind
-
-        original_stream = $stderr
-        $stderr = RSpecApprovals.stderr
-        block.call
-        RSpecApprovals.stderr.string.dup
-
-      ensure
-        $stderr = original_stream
-
+        Capture.capture :stderr, block
       end
     end
   end

--- a/spec/rspec_approvals/stream_spec.rb
+++ b/spec/rspec_approvals/stream_spec.rb
@@ -1,17 +1,22 @@
 require 'spec_helper'
 
-describe Stream::Stdout do
-  let(:proc) { Proc.new { print "hello world" } }
-
-  it "captures stdout" do
-    expect(described_class.capture proc).to eq "hello world"
+describe Stream do
+  let(:output) do
+    Proc.new do
+      print "this is stdOUT"
+      $stderr.print "this is stdERR"
+    end
   end
-end
 
-describe Stream::Stderr do
-  let(:proc) { Proc.new { $stderr.print "hello world" } }
-
-  it "captures stdout" do
-    expect(described_class.capture proc).to eq "hello world"
+  describe Stream::Stdout do
+    it "captures stdout" do
+      expect(described_class.capture output).to eq "this is stdOUT"
+    end
+  end
+  
+  describe Stream::Stderr do
+    it "captures stderr" do
+      expect(described_class.capture output).to eq "this is stdERR"
+    end
   end
 end


### PR DESCRIPTION
When using `expect { something }.to output_approval(name).to_stderr`, then if the command outputs something to stdout it is printed on screen, with no elegant way to hide it.

This is also true without the stream specifier, and with stdout.

This PR makes it so both stdout and stderr are captured whenever using `output_approval`, and only the requested stream is returned to the matcher.

