### PR TITLE
Add support for one liner syntax

### DIFF
--- a/lib/rspec_approvals/matchers/match_approval.rb
+++ b/lib/rspec_approvals/matchers/match_approval.rb
@@ -9,6 +9,9 @@ module RSpecApprovals
     end
 
     class MatchApproval < Base
+      def description
+        %[match approval "#{approval_name}"]
+      end
     end
   end
 end

--- a/lib/rspec_approvals/matchers/output_approval.rb
+++ b/lib/rspec_approvals/matchers/output_approval.rb
@@ -20,6 +20,10 @@ module RSpecApprovals
         true
       end
 
+      def description
+        %[output approval "#{approval_name}"]
+      end
+
       # Adds chained matcher, to allow:
       # expect { stream }.to output_approval(file).to_stdout
       # This is the default, and only provided for completeness.

--- a/lib/rspec_approvals/matchers/raise_approval.rb
+++ b/lib/rspec_approvals/matchers/raise_approval.rb
@@ -26,6 +26,10 @@ module RSpecApprovals
       def supports_block_expectations?
         true
       end
+
+      def description
+        %[raise approval "#{approval_name}"]
+      end
     end
   end
 end

--- a/spec/rspec_approvals/matchers/match_approval_spec.rb
+++ b/spec/rspec_approvals/matchers/match_approval_spec.rb
@@ -22,6 +22,13 @@ describe Matchers::MatchApproval do
     end
   end
 
+  describe '#description' do
+    it 'returns a description' do
+      subject.matches? 'something else'
+      expect(subject.description).to eq 'match approval "something"'
+    end
+  end
+
   describe '#matches?' do
     context 'when interactive mode is enabled' do
       subject { Matchers::MatchApproval.new 'no_such_approval' }

--- a/spec/rspec_approvals/matchers/output_approval_spec.rb
+++ b/spec/rspec_approvals/matchers/output_approval_spec.rb
@@ -9,6 +9,13 @@ describe Matchers::OutputApproval do
     end
   end
 
+  describe '#description' do
+    it 'returns a description' do
+      subject.matches? 'something else'
+      expect(subject.description).to eq 'output approval "something"'
+    end
+  end
+
   describe '#matches?' do
     context 'when interactive mode is enabled' do
       before :all do

--- a/spec/rspec_approvals/matchers/raise_approval_spec.rb
+++ b/spec/rspec_approvals/matchers/raise_approval_spec.rb
@@ -14,4 +14,11 @@ describe Matchers::RaiseApproval do
       end
     end
   end
+
+  describe '#description' do
+    it 'returns a description' do
+      subject.matches? 'something else'
+      expect(subject.description).to eq 'raise approval "raised"'
+    end
+  end
 end


### PR DESCRIPTION
Add `description` to all matchers so that rspec one liner syntax can be used:

```ruby
it { is_expected.to match_approval('filename') }
```

This cannot be used with `output_approval` or `raise_approal`, since the one liner syntax dos not support a block (https://github.com/rspec/rspec-expectations/issues/805)